### PR TITLE
Recursively check for undefined variables and skip inlining if they exist

### DIFF
--- a/test/dynamic_read_concat.js
+++ b/test/dynamic_read_concat.js
@@ -1,0 +1,17 @@
+var test = require('tap').test;
+var browserify = require('browserify');
+var path = require('path');
+
+test('dynamically loaded file gets skipped', function (t) {
+    t.plan(1);
+    
+    var b = browserify();
+    b.add(__dirname + '/files/dynamic_read_concat');
+    b.transform(path.dirname(__dirname));
+    
+    b.bundle(function (err, src) {
+        if (err) t.fail(err);
+        else t.ok(true, 'build success');
+    });
+
+});

--- a/test/dynamic_read_no_concat.js
+++ b/test/dynamic_read_no_concat.js
@@ -1,0 +1,17 @@
+var test = require('tap').test;
+var browserify = require('browserify');
+var path = require('path');
+
+test('dynamically loaded file gets skipped', function (t) {
+    t.plan(1);
+    
+    var b = browserify();
+    b.add(__dirname + '/files/dynamic_read_no_concat.js');
+    b.transform(path.dirname(__dirname));
+    
+    b.bundle(function (err, src) {
+        if (err) t.fail(err);
+        else t.ok(true, 'build success');
+    });
+
+});

--- a/test/files/dynamic_read_concat.js
+++ b/test/files/dynamic_read_concat.js
@@ -1,0 +1,8 @@
+var fs,
+    path,
+    dynamicallyCreatedFilename;
+fs = require('fs');
+path = require('path');
+
+dynamicallyCreatedFilename = path.join('/files/', 'somefile');
+var stuff = fs.readFileSync(__dirname + dynamicallyCreatedFilename + __dirname);

--- a/test/files/dynamic_read_no_concat.js
+++ b/test/files/dynamic_read_no_concat.js
@@ -1,0 +1,8 @@
+var fs,
+    path,
+    dynamicallyCreatedFilename;
+fs = require('fs');
+path = require('path');
+
+dynamicallyCreatedFilename = path.join('/files/', 'somefile');
+var stuff = fs.readFileSync(dynamicallyCreatedFilename);


### PR DESCRIPTION
Fixes https://github.com/substack/brfs/issues/5
