### PR TITLE
Only parse JS files

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ var falafel = require('falafel');
 var unparse = require('escodegen').generate;
 
 module.exports = function (file) {
-    if (/\.json$/.test(file)) return through();
+    if (!/\.js$/.test(file)) return through();
     var data = '';
     var fsNames = {};
     var vars = [ '__filename', '__dirname' ];


### PR DESCRIPTION
If the transform relies on valid JS syntax it should ensure it's parsing a JS file.
