### PR TITLE
fix fs.readFileSync() with 2 args

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,7 +77,7 @@ module.exports = function (file) {
             var fpath = Function(vars, t)(file, dirname);
             
             var enc = 'utf8';
-            if (!/^Function/.test(args[1]) && args[2]) {
+            if (args[1] && !/^Function/.test(args[1].type)) {
                 enc = Function('return ' + unparse(args[1]))()
             }
             

--- a/test/encoding.js
+++ b/test/encoding.js
@@ -1,0 +1,19 @@
+var test = require('tap').test;
+var browserify = require('browserify');
+
+var vm = require('vm');
+var path = require('path');
+
+test('sync string encoding', function (t) {
+    t.plan(1);
+    var b = browserify(__dirname + '/files/encoding.js');
+    b.transform(path.dirname(__dirname));
+    b.bundle(function (err, src) {
+        if (err) t.fail(err);
+        vm.runInNewContext(src, {
+            setTimeout: setTimeout,
+            console: { log: log }
+        });
+    });
+    function log (msg) { t.equal(msg, '3c623e6265657020626f6f703c2f623e0a') }
+});

--- a/test/files/encoding.js
+++ b/test/files/encoding.js
@@ -1,0 +1,4 @@
+var fs = require('fs');
+var txt = fs.readFileSync(__dirname + '/robot.html', { encoding: 'hex' });
+
+console.log(txt);


### PR DESCRIPTION
Right now this doesn't work:

``` js
var txt = fs.readFileSync(__dirname + '/robot.html', { encoding: 'hex' });
```

With this PR, it now works. Test added, too.

I think your logic on the function test had two bugs and they canceled each other out. (found with the help of @dcposch)
