### PR TITLE
Add support for fs.readdir and fs.readdirSync

### DIFF
--- a/test/files/readdir-sync.js
+++ b/test/files/readdir-sync.js
@@ -1,0 +1,3 @@
+var fs = require('fs');
+
+console.log(fs.readdirSync(__dirname));

--- a/test/files/readdir.js
+++ b/test/files/readdir.js
@@ -1,0 +1,6 @@
+var fs = require('fs');
+
+fs.readdir(__dirname, function(err, files) {
+  if (err) throw err;
+  console.log(files);
+});

--- a/test/readdir.js
+++ b/test/readdir.js
@@ -1,0 +1,43 @@
+var browserify = require('browserify');
+var test = require('tap').test;
+
+var path = require('path');
+var vm = require('vm');
+var fs = require('fs');
+
+test('readdir', function(t) {
+    t.plan(1);
+
+    var expected = fs.readdirSync(__dirname + '/files');
+    var b = browserify(__dirname + '/files/readdir.js');
+    b.transform(path.dirname(__dirname));
+    b.bundle(function(err, src) {
+        if (err) t.fail(err);
+        vm.runInNewContext(src, {
+            console: { log: log },
+            setTimeout: setTimeout
+        });
+    });
+
+    function log(actual) {
+        t.deepEqual(expected, actual);
+    }
+});
+
+test('readdirSync', function(t) {
+    t.plan(1);
+
+    var expected = fs.readdirSync(__dirname + '/files');
+    var b = browserify(__dirname + '/files/readdir-sync.js');
+    b.transform(path.dirname(__dirname));
+    b.bundle(function(err, src) {
+        if (err) t.fail(err);
+        vm.runInNewContext(src, {
+            console: { log: log }
+        });
+    });
+
+    function log(actual) {
+        t.deepEqual(expected, actual);
+    }
+});


### PR DESCRIPTION
Comes in handy when writing demos, for example taking a directory of images and being able to pull a list of them in without needing to specify them manually.

Happy to rewrite as a separate transform, but thought it might belong here – let me know what you think :) Thanks!
