### PR TITLE
Add regex to check for .css files

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ var path = require('path');
 
 module.exports = function (file, opts) {
     if (/\.json$/.test(file)) return through();
+    if (/\.css$/.test(file)) return through();
     var vars = {
         __filename: file,
         __dirname: path.dirname(file)


### PR DESCRIPTION
Currently brfs will attempt to process css files if they are included from the node_modules folder. This check will assure that brfs will never attempt to process .css files if they somehow get processed by the transform.

I am not 100% sure this is the most elegant solution to the problem due to the nature of the edge case necessitating this bug fix, attempting to require a .css file from a submodule

```
require('beep/boop.css');
```

In this particular case the transform is not run on this require statement, due to it not being in a submodule.  If the transform is run globally instead (-g), brfs attempts to process the css file on the first pass.

My reservation is that I'm not completely sure that brfs should care about specific file types, although since .json is already explicitly ignored perhaps my intuition is wrong.  My main concern is that the number of potential dot files is infinite.  Would it perhaps be better to make a white list rather than a black list?
