### PR TITLE
Remove encoding in fs.readFileSync example

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -84,7 +84,7 @@ process.nextTick(function () {(function (err, html) {
 
 brfs looks for:
 
-* `fs.readFileSync(pathExpr, enc='utf8')`
+* `fs.readFileSync(pathExpr, enc=null)`
 * `fs.readFile(pathExpr, enc=null, cb)`
 * `fs.readdirSync(pathExpr, cb)`
 * `fs.readdir(pathExpr, cb)`


### PR DESCRIPTION
The list looks like an API example and may be misunderstood that `utf8` is the default value, but it isn't.
