### PR TITLE
add ignore option

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,10 @@ var path = require('path');
 var resolve = require('resolve');
 
 module.exports = function (file, opts) {
-    if (/\.json$/.test(file)) return through();
+    var ignore = opts.ignore || opts.i || /\.json$/;
+    if (typeof ignore === 'string') { ignore = new RegExp(ignore); }
+
+    if (ignore.test(file)) return through();
     
     function resolver (p) {
         return resolve.sync(p, { basedir: path.dirname(file) });

--- a/readme.markdown
+++ b/readme.markdown
@@ -125,6 +125,10 @@ Optionally, you can set which `opts.vars` will be used in the
 [static argument evaluation](https://npmjs.org/package/static-eval)
 in addition to `__dirname` and `__filename`.
 
+`opts.ignore` can be used to skip certain files. It expects a `RegExp` but
+if a string is given it will convert. If omitted the default of `/\.json$/`
+is used.
+
 # events
 
 ## tr.on('file', function (file) {})


### PR DESCRIPTION
Hi, for a project I'm working on we sometimes have non-js files going through the browserify pipeline. To avoid a parser error I'd like to add support for `opts.ignore`.

Thanks