### PR TITLE
Ensure readFileSync emits error to bundler

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,6 +79,7 @@ module.exports = function (file, opts) {
             enc = enc.encoding;
         }
         var stream = fs.createReadStream(file,  { encoding: enc })
+            .on('error', function (err) { sm.emit('error', err) })
             .pipe(quote()).pipe(through(write, end))
         ;
         if (isBuffer) {


### PR DESCRIPTION
Currently if the file is not found (i.e. a typo during development) the build will crash because of an unhandled `'error'` event.

With this change the bundler will receive an error (like with `readFile` and `readdirSync`), so that development tools like watchify and budo will not crash.

Related: https://github.com/mattdesl/budo/issues/84