### PR TITLE
Fix fs.readdirSync arguments in readme

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -86,7 +86,7 @@ brfs looks for:
 
 * `fs.readFileSync(pathExpr, enc=null)`
 * `fs.readFile(pathExpr, enc=null, cb)`
-* `fs.readdirSync(pathExpr, cb)`
+* `fs.readdirSync(pathExpr)`
 * `fs.readdir(pathExpr, cb)`
 
 Inside of each `pathExpr`, you can use


### PR DESCRIPTION
`fs.readdirSync()` only takes one argument (the path), no callback - trivial readme fix

https://nodejs.org/api/fs.html#fs_fs_readdirsync_path