### PR TITLE
make brfs standalone work

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 var fs = require('fs');
 var path = require('path');
-var brfs = require('../');
+var brfs = require('brfs');
 var file = process.argv[2];
 
 if (file === '-h' || file === '--help') {


### PR DESCRIPTION
Running `brfs` as a standalone command has never worked.

I have always used it before as a browserify transform.

This `PR` `requires('brfs')` in the `bin/cmd.js`